### PR TITLE
Custom headers

### DIFF
--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -1,4 +1,4 @@
-import adapter from '../src'
+import adapter, { ajaxOptions } from '../src'
 global.fetch = require('jest-fetch-mock')
 
 adapter.apiPath = '/api'
@@ -22,6 +22,20 @@ function injectFail (values) {
 }
 
 describe('adapter', () => {
+  describe('ajaxOptions(options)', () => {
+    it('allows to define custom headers', () => {
+      const options = ajaxOptions({
+        headers: {
+          'some-header': 'test1',
+          'some-other-header': 'test2'
+        }
+      })
+
+      expect(options.headers.get('some-header')).toEqual('test1')
+      expect(options.headers.get('some-other-header')).toEqual('test2')
+    })
+  })
+
   describe('ajax', () => {
     describe('when it fails with a malformed response', () => {
       const values = 'ERROR'

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -21,7 +21,40 @@ function injectFail (values) {
   )
 }
 
+function testCommonOptions (method) {
+  return it('deep merges the default `commonOptions` with the passed options', () => {
+    adapter.commonOptions = {
+      headers: {
+        'some-header': 'test1'
+      }
+    }
+
+    const options = {
+      headers: {
+        'some-other-header': 'test2'
+      }
+    }
+
+    injectDone({})
+
+    const args = method === 'del'
+      ? ['/users', options]
+      : ['/users', null, options]
+
+    const request = adapter[method].apply(adapter, args)
+
+    return request.promise.then(() => {
+      expect(lastRequest().headers.get('some-header')).toEqual('test1')
+      expect(lastRequest().headers.get('some-other-header')).toEqual('test2')
+    })
+  })
+}
+
 describe('adapter', () => {
+  beforeEach(() => {
+    adapter.commonOptions = {}
+  })
+
   describe('ajaxOptions(options)', () => {
     it('allows to define custom headers', () => {
       const options = ajaxOptions({
@@ -61,6 +94,8 @@ describe('adapter', () => {
     const action = () => {
       ret = adapter.get('/users', data)
     }
+
+    testCommonOptions('get')
 
     describe('when it resolves', () => {
       const values = { id: 1, name: 'paco' }
@@ -106,6 +141,8 @@ describe('adapter', () => {
     const action = () => {
       ret = adapter.post('/users', data)
     }
+
+    testCommonOptions('post')
 
     describe('when it resolves', () => {
       const values = { id: 1, name: 'paco' }
@@ -155,6 +192,8 @@ describe('adapter', () => {
       ret = adapter.put('/users', data)
     }
 
+    testCommonOptions('put')
+
     describe('when it resolves', () => {
       const values = { id: 1, name: 'paco' }
 
@@ -198,6 +237,8 @@ describe('adapter', () => {
     const action = () => {
       ret = adapter.del('/users')
     }
+
+    testCommonOptions('del')
 
     describe('when it resolves', () => {
       const values = { id: 1, name: 'paco' }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test": "npm run flow && npm run lint && npm run jest"
   },
   "dependencies": {
+    "deep-extend": "^0.4.1",
     "qs": "^6.4.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* global fetch, Headers, Request */
 // @flow
 import qs from 'qs'
+import deepExtend from 'deep-extend'
 type OptionsRequest = {
   abort: () => void;
   promise: Promise<*>;
@@ -61,32 +62,33 @@ function ajax (url: string, options: Options): OptionsRequest {
 
 export default {
   apiPath: '',
+  commonOptions: {},
 
   get (path: string, data: ?{}, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      Object.assign({}, { method: 'GET', data }, options)
+      deepExtend({}, { method: 'GET' }, this.commonOptions, options, { data })
     )
   },
 
   post (path: string, data: ?{}, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      Object.assign({}, { method: 'POST', data }, options)
+      deepExtend({}, { method: 'POST' }, this.commonOptions, options, { data })
     )
   },
 
   put (path: string, data: ?{}, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      Object.assign({}, { method: 'PUT', data }, options)
+      deepExtend({}, { method: 'PUT' }, this.commonOptions, options, { data })
     )
   },
 
   del (path: string, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      Object.assign({}, { method: 'DELETE' }, options)
+      deepExtend({}, { method: 'DELETE' }, this.commonOptions, options)
     )
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,16 @@ type OptionsRequest = {
 type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 type Options = {
   method: Method;
+  headers?: ?{ [key: string]: string };
   onProgress?: (num: number) => mixed;
   data?: ?{ [key: string]: mixed };
 }
 
-function ajaxOptions (options: Options): any {
-  const headers = new Headers()
-  headers.append('Content-Type', 'application/json')
+export function ajaxOptions (options: Options): any {
+  const headers = new Headers(Object.assign({}, {
+    'Content-Type': 'application/json'
+  }, options.headers))
+
   return {
     method: options.method,
     headers,


### PR DESCRIPTION
This PR allows two things:

- Pass custom headers to `get`, `post`, `put` and `del`.
- Define base options for all requests using `commonOptions` on the adapter initialization.

Example:

```es6
apiClient(adapter, {
  apiPath: '/',
  commonOptions: {
    headers: {
      authtoken:  'SOME-AUTH-TOKEN',
    }
  }
})
```