### PR TITLE
Fixes rejection based on the response status code

### DIFF
--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -120,7 +120,7 @@ describe('adapter', () => {
     })
 
     describe('when it fails', () => {
-      const values = '{"errors": ["foo"]}'
+      const values = {errors: ['foo']}
 
       beforeEach(() => {
         injectFail(values)
@@ -171,7 +171,7 @@ describe('adapter', () => {
     })
 
     describe('when it fails', () => {
-      const values = '{"errors": ["foo"]}'
+      const values = {errors: ['foo']}
 
       beforeEach(() => {
         data = { name: 'paco' }
@@ -222,7 +222,7 @@ describe('adapter', () => {
     })
 
     describe('when it fails', () => {
-      const values = '{"errors": ["foo"]}'
+      const values = {errors: ['foo']}
 
       beforeEach(() => {
         injectFail(values)
@@ -269,7 +269,7 @@ describe('adapter', () => {
     })
 
     describe('when it fails', () => {
-      const values = '{"errors": ["foo"]}'
+      const values = {errors: ['foo']}
 
       beforeEach(() => {
         injectFail(values)

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -90,7 +90,7 @@ describe('adapter', () => {
       it('returns a rejected promise with the parsed json', () => {
         expect.assertions(1)
 
-        const someData = { errors: { name: 'Already in use' } }
+        const someData = { errors: { name: 'Already in use' } }
         const response = {
           ok: false,
           json: () => Promise.resolve(someData)

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -79,6 +79,8 @@ describe('adapter', () => {
       })
 
       it('returns the error wrapper into an array', () => {
+        expect.assertions(2)
+
         expect(ret.abort).toBeTruthy()
 
         return ret.promise.catch((vals) => {
@@ -126,6 +128,8 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
+        expect.assertions(2)
+
         expect(ret.abort).toBeTruthy()
 
         return ret.promise.catch((vals) => {
@@ -176,6 +180,8 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
+        expect.assertions(2)
+
         expect(ret.abort).toBeTruthy()
 
         return ret.promise.catch((vals) => {
@@ -224,6 +230,8 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
+        expect.assertions(2)
+
         expect(ret.abort).toBeTruthy()
 
         return ret.promise.catch((vals) => {
@@ -269,6 +277,8 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
+        expect.assertions(2)
+
         expect(ret.abort).toBeTruthy()
 
         return ret.promise.catch((vals) => {

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -1,4 +1,4 @@
-import adapter, { ajaxOptions } from '../src'
+import adapter, { ajaxOptions, checkStatus } from '../src'
 global.fetch = require('jest-fetch-mock')
 
 adapter.apiPath = '/api'
@@ -66,6 +66,40 @@ describe('adapter', () => {
 
       expect(options.headers.get('some-header')).toEqual('test1')
       expect(options.headers.get('some-other-header')).toEqual('test2')
+    })
+  })
+
+  describe('checkStatus(response)', () => {
+    describe('if response is ok', () => {
+      it('returns a resolved promise with the parsed json', () => {
+        expect.assertions(1)
+
+        const someData = { data: 'ok' }
+        const response = {
+          ok: true,
+          json: () => Promise.resolve(someData)
+        }
+
+        return checkStatus(response).then(json => {
+          expect(json).toEqual(someData)
+        })
+      })
+    })
+
+    describe('if response is not ok', () => {
+      it('returns a rejected promise with the parsed json', () => {
+        expect.assertions(1)
+
+        const someData = { errors: { name: 'Already in use' } }
+        const response = {
+          ok: false,
+          json: () => Promise.resolve(someData)
+        }
+
+        return checkStatus(response).catch(json => {
+          expect(json).toEqual(someData)
+        })
+      })
     })
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,12 @@ export function ajaxOptions (options: Options): any {
   }
 }
 
+export function checkStatus (response): any {
+  return response.json().then(json => {
+    return response.ok ? json : Promise.reject(json)
+  });
+}
+
 function parseJson (str: string): ?{[key: string]: mixed} {
   try {
     return JSON.parse(str)
@@ -43,16 +49,11 @@ function ajax (url: string, options: Options): OptionsRequest {
   const request = new Request(url, ajaxOptions(options))
   const xhr = fetch(request)
   const promise = new Promise((resolve, reject) => {
-    xhr.then(
-      (response) => {
-        response.json().then(resolve)
-      },
-      (error) => {
-        const json = parseJson(error)
-        const ret = json ? json.errors : {}
+    xhr.then(checkStatus).then(resolve, (error) => {
+      const ret = error ? error.errors : {}
 
-        return reject(ret || {})
-      })
+      return reject(ret || {})
+    })
   })
 
   const abort = () => {} // noop, fetch is not cancelable

--- a/src/index.js
+++ b/src/index.js
@@ -27,18 +27,10 @@ export function ajaxOptions (options: Options): any {
   }
 }
 
-export function checkStatus (response): any {
+export function checkStatus (response: any): any {
   return response.json().then(json => {
     return response.ok ? json : Promise.reject(json)
-  });
-}
-
-function parseJson (str: string): ?{[key: string]: mixed} {
-  try {
-    return JSON.parse(str)
-  } catch (_error) {
-    return null
-  }
+  })
 }
 
 function ajax (url: string, options: Options): OptionsRequest {


### PR DESCRIPTION
This fixes error catching on `fetch`, that unlike jquery, it doesn't automatically rejects requests that responded http error codes.

The existing rejection tests were failing silently.

#### Docs
https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API

>The fetch() method takes one mandatory argument, the path to the resource you want to fetch. It returns a promise that resolves to the Response to that request, whether it is successful or not. 

https://developer.mozilla.org/en-US/docs/Web/API/Response/ok

>The ok read-only property of the Response interface contains a boolean stating whether the response was successful (status in the range 200-299) or not.