### PR TITLE
Custom fetch options

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
     "es2015"
   ],
   "plugins": [
-    "transform-flow-strip-types"
+    "transform-flow-strip-types",
+    "transform-object-rest-spread"
   ]
 }

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -67,6 +67,14 @@ describe('adapter', () => {
       expect(options.headers.get('some-header')).toEqual('test1')
       expect(options.headers.get('some-other-header')).toEqual('test2')
     })
+
+    it('allows to pass any option to fetch', () => {
+      const options = ajaxOptions({
+        credentials: 'same-origin'
+      })
+
+      expect(options.credentials).toEqual('same-origin')
+    })
   })
 
   describe('checkStatus(response)', () => {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-eslint": "^7.1.1",
     "babel-jest": "^18.0.0",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "6.23.0",
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.9.0",

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export function ajaxOptions (options: Options): any {
   }, options.headers))
 
   return {
+    ...options,
     method: options.method,
     headers,
     body: options.data ? JSON.stringify(options.data) : null

--- a/src/index.js
+++ b/src/index.js
@@ -16,15 +16,15 @@ type Options = {
 }
 
 export function ajaxOptions (options: Options): any {
-  const headers = new Headers(Object.assign({}, {
+  const { headers, data, ...otherOptions } = options
+  const headersObject = new Headers(Object.assign({}, {
     'Content-Type': 'application/json'
-  }, options.headers))
+  }, headers))
 
   return {
-    ...options,
-    method: options.method,
-    headers,
-    body: options.data ? JSON.stringify(options.data) : null
+    ...otherOptions,
+    headers: headersObject,
+    body: data ? JSON.stringify(data) : null
   }
 }
 


### PR DESCRIPTION
I need to define `credentials: 'same-origin'` to receive some cookies through `fetch`, but the adapter only allows to customize/override the `body`, `header` and `method` options.

This PR allows to pass any option to `fetch`. In my case, I'm doing something like this:

```
apiClient(adapter, {
  apiPath: '/',
  commonOptions: {
    credentials: 'same-origin',
  },
})
```