### PR TITLE
Reject promise on abort

### DIFF
--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -130,6 +130,16 @@ describe('adapter', () => {
         })
       })
     })
+
+    describe('when aborted', () => {
+      it('rejects the request promise with an "abort" message', () => {
+        const { abort, promise } = adapter.get()
+
+        abort()
+
+        return expect(promise).rejects.toBe('abort')
+      })
+    })
   })
 
   describe('get', () => {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.9.0",
     "flow-bin": "^0.38.0",
-    "jest": "^18.1.0",
+    "jest": "^20.0.4",
     "jest-fetch-mock": "^1.0.8",
     "snazzy": "^6.0.0",
     "standard": "^8.6.0"

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,11 @@ function ajax (url: string, options: Options): OptionsRequest {
   }
   const request = new Request(url, ajaxOptions(options))
   const xhr = fetch(request)
+  let rejectPromise
+
   const promise = new Promise((resolve, reject) => {
+    rejectPromise = reject
+
     xhr.then(checkStatus).then(resolve, (error) => {
       const ret = error ? error.errors : {}
 
@@ -49,7 +53,7 @@ function ajax (url: string, options: Options): OptionsRequest {
     })
   })
 
-  const abort = () => {} // noop, fetch is not cancelable
+  const abort = () => rejectPromise('abort')
 
   return { abort, promise }
 }


### PR DESCRIPTION
`fetch` request can't be canceled, but we can still reject the promise to signal `mobx-rest`. `mobx-rest-jquery-adapter` also rejects the promise when the ajax request is canceled.

I made this branch from v0.0.7, so it has some conflicts to resolve.