### PR TITLE
Only set JSON Content-Type if there's a request body

### DIFF
--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -132,7 +132,7 @@ describe('adapter', () => {
     })
 
     describe('when aborted', () => {
-      it.only('rejects the request promise with an "abort" message', () => {
+      it('rejects the request promise with an "abort" message', () => {
         const { abort, promise } = adapter.get()
 
         abort()
@@ -168,9 +168,7 @@ describe('adapter', () => {
           expect(vals).toEqual(values)
           expect(lastRequest().url).toBe('/api/users?manager_id=2')
           expect(lastRequest().method).toBe('GET')
-          expect(lastRequest().headers.map['content-type']).toEqual([
-            'application/json'
-          ])
+          expect(lastRequest().headers.map).toEqual({})
         })
       })
     })
@@ -323,9 +321,7 @@ describe('adapter', () => {
           expect(vals).toEqual(values)
           expect(lastRequest().url).toEqual('/api/users')
           expect(lastRequest().method).toBe('DELETE')
-          expect(lastRequest().headers.map['content-type']).toEqual([
-            'application/json'
-          ])
+          expect(lastRequest().headers.map).toEqual({})
         })
       })
     })

--- a/package.json
+++ b/package.json
@@ -53,14 +53,14 @@
     "flow": "flow",
     "test": "npm run flow && npm run lint && npm run jest",
     "format": "prettier-standard --print-width 60 \"{src,__tests__}/**/*.js\"",
-    "prepush": "npm test",
-    "lint-staged": {
-      "linters": {
-        "{src|__tests__}/**/*.js": [
-          "prettier-standard",
-          "git add"
-        ]
-      }
+    "prepush": "npm test"
+  },
+  "lint-staged": {
+    "linters": {
+      "{src|__tests__}/**/*.js": [
+        "prettier-standard",
+        "git add"
+      ]
     }
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -25,12 +25,14 @@ export function ajaxOptions (options: Options): any {
     HeadersConstructor = ponyfill().Headers
   }
 
+  const baseHeaders = {}
+  if (data) {
+    baseHeaders['Content-Type'] = 'application/json'
+  }
+
   const headersObject = new HeadersConstructor(
     Object.assign(
-      {},
-      {
-        'Content-Type': 'application/json'
-      },
+      baseHeaders,
       headers
     )
   )


### PR DESCRIPTION
Update tests accordingly.

Fix bad lint-staged config (doesn't belong inside scripts).

Fixes #8

Linting still fails, but it already did on master, and I have no idea why or how to fix it - I had the same problem on the mobx-rest repo.
```
/.../mobx-rest-fetch-adapter/src/index.js
   7:6   error  'OptionsRequest' is not defined  no-undef
  12:6   error  'Method' is not defined          no-undef
  13:6   error  'Options' is not defined         no-undef
  14:11  error  'Method' is not defined          no-undef
```