### PR TITLE
QS options

### DIFF
--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -1,4 +1,5 @@
 import adapter, { ajaxOptions, checkStatus } from '../src'
+import qs from 'qs'
 
 global.fetch = require('jest-fetch-mock')
 adapter.apiPath = '/api'
@@ -141,6 +142,15 @@ describe('adapter', () => {
           expect(vals).toEqual('abort')
         })
       })
+    })
+
+    it('should allow to pass options to qs.stringify', () => {
+      const data = { someArray: [1, 2, 3] }
+      const qsOptions = { indices: false }
+
+      adapter.get('/users', data, { qsOptions })
+
+      expect(lastRequest().url.split('?')[1]).toEqual(qs.stringify(data, qsOptions))
     })
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ type Options = {
   method: Method,
   headers?: ?{ [key: string]: string },
   onProgress?: (num: number) => mixed,
-  data?: ?{ [key: string]: mixed }
+  data?: ?{ [key: string]: mixed },
+  qsOptions?: ?{ [key: mixed]: mixed }
 }
 
 export function ajaxOptions (options: Options): any {
@@ -52,7 +53,7 @@ function ajax (url: string, options: Options): OptionsRequest {
   let rejectPromise
 
   if (options.method === 'GET' && options.data) {
-    url = `${url}?${qs.stringify(options.data)}`
+    url = `${url}?${qs.stringify(options.data, options.qsOptions)}`
     delete options.data
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ function ajax (url: string, options: Options): OptionsRequest {
   if (options.method === 'GET' && options.data) {
     url = `${url}?${qs.stringify(options.data, options.qsOptions)}`
     delete options.data
+    delete options.qsOptions
   }
 
   if (typeof fetchMethod === 'undefined') {


### PR DESCRIPTION
Allows to pass options to `qs.stringify`. In my particular case I'm doing this:

```es6
apiClient(adapter, {
  commonOptions: {
    qsOptions: {
      arrayFormat: 'brackets'
    }
  }
})
```