### PR TITLE
General improvements

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,4 +7,3 @@
 [options]
 esproposal.class_instance_fields=enable
 esproposal.decorators=ignore
-unsafe.enable_getters_and_setters=true

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -39,7 +39,10 @@ function testDefaults (method) {
 
     injectDone({})
 
-    const args = ['/users', options]
+    const args = method === 'del'
+      ? ['/users', options]
+      : ['/users', {}, options]
+
     const request = adapter[method].apply(adapter, args)
 
     return request.promise.then(() => {
@@ -162,7 +165,7 @@ describe('adapter', () => {
       const data = { someArray: [1, 2, 3] }
       const qsOptions = { indices: false }
 
-      adapter.get('/users', { data, qs: qsOptions })
+      adapter.get('/users', data, { qs: qsOptions })
 
       expect(lastRequest().url.split('?')[1]).toEqual(qs.stringify(data, qsOptions))
     })
@@ -172,7 +175,7 @@ describe('adapter', () => {
     const data = { manager_id: 2 }
 
     const action = () => {
-      ret = adapter.get('/users', { data })
+      ret = adapter.get('/users', data)
     }
 
     testDefaults('get')
@@ -221,7 +224,7 @@ describe('adapter', () => {
     let data
 
     const action = () => {
-      ret = adapter.post('/users', { data })
+      ret = adapter.post('/users', data)
     }
 
     testDefaults('post')
@@ -275,7 +278,7 @@ describe('adapter', () => {
     const data = { name: 'paco' }
 
     const action = () => {
-      ret = adapter.put('/users', { data })
+      ret = adapter.put('/users', data)
     }
 
     testDefaults('put')

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -77,6 +77,15 @@ describe('adapter', () => {
 
       expect(options.credentials).toEqual('same-origin')
     })
+
+    describe('if options.data is not specified', () => {
+      // https://github.com/github/fetch/issues/402
+      it('body should be undefined', () => {
+        const options = ajaxOptions({ data: null })
+
+        expect(options.body).toBeUndefined()
+      })
+    })
   })
 
   describe('checkStatus(response)', () => {

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -146,7 +146,7 @@ describe('adapter', () => {
       const data = { someArray: [1, 2, 3] }
       const qsOptions = { indices: false }
 
-      adapter.get('/users', { data, qsOptions })
+      adapter.get('/users', { data, qs: qsOptions })
 
       expect(lastRequest().url.split('?')[1]).toEqual(qs.stringify(data, qsOptions))
     })

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -23,9 +23,9 @@ function injectFail (values) {
   global.fetch.mockResponseOnce(JSON.stringify(values), { status: 422 })
 }
 
-function testCommonOptions (method) {
-  return it('deep merges the default `commonOptions` with the passed options', () => {
-    adapter.commonOptions = {
+function testDefaults (method) {
+  return it('deep merges the default `defaults` with the passed options', () => {
+    adapter.defaults = {
       headers: {
         'some-header': 'test1'
       }
@@ -53,7 +53,7 @@ function testCommonOptions (method) {
 
 describe('adapter', () => {
   beforeEach(() => {
-    adapter.commonOptions = {}
+    adapter.defaults = {}
   })
 
   describe('ajaxOptions(options)', () => {
@@ -161,7 +161,7 @@ describe('adapter', () => {
       ret = adapter.get('/users', data)
     }
 
-    testCommonOptions('get')
+    testDefaults('get')
 
     describe('when it resolves', () => {
       const values = { id: 1, name: 'paco' }
@@ -210,7 +210,7 @@ describe('adapter', () => {
       ret = adapter.post('/users', data)
     }
 
-    testCommonOptions('post')
+    testDefaults('post')
 
     describe('when it resolves', () => {
       const values = { id: 1, name: 'paco' }
@@ -264,7 +264,7 @@ describe('adapter', () => {
       ret = adapter.put('/users', data)
     }
 
-    testCommonOptions('put')
+    testDefaults('put')
 
     describe('when it resolves', () => {
       const values = { id: 1, name: 'paco' }
@@ -314,7 +314,7 @@ describe('adapter', () => {
       ret = adapter.del('/users')
     }
 
-    testCommonOptions('del')
+    testDefaults('del')
 
     describe('when it resolves', () => {
       const values = { id: 1, name: 'paco' }

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -1,4 +1,5 @@
 import adapter, { ajaxOptions, checkStatus } from '../src'
+import qs from 'qs'
 
 global.fetch = require('jest-fetch-mock')
 adapter.apiPath = '/api'
@@ -141,6 +142,15 @@ describe('adapter', () => {
           expect(vals).toEqual('abort')
         })
       })
+    })
+
+    it('should allow to pass options to qs.stringify', () => {
+      const data = { someArray: [1, 2, 3] }
+      const qsOptions = { indices: false }
+
+      adapter.get('/users', data, { qsOptions })
+
+      expect(lastRequest().url.split('?')[1]).toEqual(qs.stringify(data, qsOptions))
     })
   })
 

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -129,7 +129,7 @@ describe('adapter', () => {
         expect(ret.abort).toBeTruthy()
 
         return ret.promise.catch(vals => {
-          expect(vals.json).toEqual({})
+          expect(vals.error).toEqual({})
         })
       })
     })
@@ -141,7 +141,7 @@ describe('adapter', () => {
         const ret = adapter.get('/users')
 
         return ret.promise.catch(vals => {
-          expect(vals.response.status).toBe(404)
+          expect(vals.requestResponse.status).toBe(404)
         })
       })
     })
@@ -211,7 +211,7 @@ describe('adapter', () => {
         expect(ret.abort).toBeTruthy()
 
         return ret.promise.catch(vals => {
-          expect(vals.json).toEqual(['foo'])
+          expect(vals.error).toEqual(['foo'])
         })
       })
     })
@@ -265,7 +265,7 @@ describe('adapter', () => {
         expect(ret.abort).toBeTruthy()
 
         return ret.promise.catch(vals => {
-          expect(vals.json).toEqual(['foo'])
+          expect(vals.error).toEqual(['foo'])
         })
       })
     })
@@ -317,7 +317,7 @@ describe('adapter', () => {
         expect(ret.abort).toBeTruthy()
 
         return ret.promise.catch(vals => {
-          expect(vals.json).toEqual(['foo'])
+          expect(vals.error).toEqual(['foo'])
         })
       })
     })
@@ -364,7 +364,7 @@ describe('adapter', () => {
         expect(ret.abort).toBeTruthy()
 
         return ret.promise.catch(vals => {
-          expect(vals.json).toEqual(['foo'])
+          expect(vals.error).toEqual(['foo'])
         })
       })
     })

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -39,9 +39,7 @@ function testDefaults (method) {
 
     injectDone({})
 
-    const args =
-      method === 'del' ? ['/users', options] : ['/users', null, options]
-
+    const args = ['/users', options]
     const request = adapter[method].apply(adapter, args)
 
     return request.promise.then(() => {
@@ -148,7 +146,7 @@ describe('adapter', () => {
       const data = { someArray: [1, 2, 3] }
       const qsOptions = { indices: false }
 
-      adapter.get('/users', data, { qsOptions })
+      adapter.get('/users', { data, qsOptions })
 
       expect(lastRequest().url.split('?')[1]).toEqual(qs.stringify(data, qsOptions))
     })
@@ -158,7 +156,7 @@ describe('adapter', () => {
     const data = { manager_id: 2 }
 
     const action = () => {
-      ret = adapter.get('/users', data)
+      ret = adapter.get('/users', { data })
     }
 
     testDefaults('get')
@@ -207,7 +205,7 @@ describe('adapter', () => {
     let data
 
     const action = () => {
-      ret = adapter.post('/users', data)
+      ret = adapter.post('/users', { data })
     }
 
     testDefaults('post')
@@ -261,7 +259,7 @@ describe('adapter', () => {
     const data = { name: 'paco' }
 
     const action = () => {
-      ret = adapter.put('/users', data)
+      ret = adapter.put('/users', { data })
     }
 
     testDefaults('put')

--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -2,7 +2,7 @@ import adapter, { ajaxOptions, checkStatus } from '../src'
 import qs from 'qs'
 
 global.fetch = require('jest-fetch-mock')
-adapter.apiPath = '/api'
+adapter.urlRoot = '/api'
 
 let ret
 function lastRequest () {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.9.0",
-    "flow-bin": "^0.38.0",
+    "flow-bin": "^0.63.1",
     "flow-copy-source": "^1.1.0",
     "husky": "^0.13.4",
     "jest": "^18.1.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "jest": "^18.1.0",
     "jest-fetch-mock": "^1.0.8",
     "prettier-standard": "^5.0.0",
+    "rimraf": "^2.6.1",
     "snazzy": "^6.0.0",
-    "standard": "^8.6.0",
-    "rimraf": "^2.6.1"
+    "standard": "^8.6.0"
   },
   "main": "lib",
   "scripts": {
@@ -65,7 +65,6 @@
   },
   "dependencies": {
     "lodash.merge": "^4.6.0",
-    "fetch-ponyfill": "^4.0.0",
     "qs": "^6.4.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -101,12 +101,20 @@ const adapter = {
     const abort = () => rejectPromise('abort')
 
     return { abort, promise }
+  },
+
+  del (path: string, options?: {}): AdapterRequest {
+    return this.request(path, merge({ method: 'DELETE' }, options))
   }
 }
 
 for (const method in methodsMapping) {
-  adapter[method] = function (path: string, options?: {}): AdapterRequest {
-    return this.request(path, merge({ method: methodsMapping[method] }, options))
+  if (method === 'del') {
+    continue
+  }
+
+  adapter[method] = function (path: string, data?: {}, options?: {}): AdapterRequest {
+    return this.request(path, merge({ method: methodsMapping[method] }, options, { data }))
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ type Options = {
   method: Method,
   headers?: ?{ [key: string]: string },
   onProgress?: (num: number) => mixed,
-  data?: ?{ [key: string]: mixed }
+  data?: ?{ [key: string]: mixed },
+  qsOptions?: ?{ [key: mixed]: mixed }
 }
 
 export function ajaxOptions (options: Options): any {
@@ -52,7 +53,7 @@ function ajax (url: string, options: Options): OptionsRequest {
   let rejectPromise
 
   if (options.method === 'GET' && options.data) {
-    url = `${url}?${qs.stringify(options.data)}`
+    url = `${url}?${qs.stringify(options.data, options.qsOptions)}`
     delete options.data
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ function ajax (url: string, options: Options): OptionsRequest {
   if (options.method === 'GET' && options.data) {
     url = `${url}?${qs.stringify(options.data, options.qsOptions)}`
     delete options.data
+    delete options.qsOptions
   }
 
   if (typeof fetchMethod === 'undefined') {

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export function ajaxOptions (options: RequestOptions): any {
   return {
     ...otherOptions,
     headers: headersObject,
-    body: data ? JSON.stringify(data) : null
+    body: data ? JSON.stringify(data) : undefined
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -58,11 +58,11 @@ const methodsMapping = {
 }
 
 const adapter = {
-  apiPath: '',
+  urlRoot: '',
   defaults: {},
 
   request (method: string, path: string, options?: {} = {}): OptionsRequest {
-    let url = `${this.apiPath}${path}`
+    let url = `${this.urlRoot}${path}`
     let fetchMethod = fetch
     let rejectPromise
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,33 +79,33 @@ function ajax (url: string, options: Options): OptionsRequest {
 
 export default {
   apiPath: '',
-  commonOptions: {},
+  defaults: {},
 
   get (path: string, data: ?{}, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      merge({ method: 'GET' }, this.commonOptions, options, { data })
+      merge({ method: 'GET' }, this.defaults, options, { data })
     )
   },
 
   post (path: string, data: ?{}, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      merge({ method: 'POST' }, this.commonOptions, options, { data })
+      merge({ method: 'POST' }, this.defaults, options, { data })
     )
   },
 
   put (path: string, data: ?{}, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      merge({ method: 'PUT' }, this.commonOptions, options, { data })
+      merge({ method: 'PUT' }, this.defaults, options, { data })
     )
   },
 
   del (path: string, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      merge({ method: 'DELETE' }, this.commonOptions, options)
+      merge({ method: 'DELETE' }, this.defaults, options)
     )
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -91,8 +91,8 @@ const adapter = {
         .catch(response => {
           response.json().then(error => {
             reject({
-              response,
-              json: this.errorUnwrap(error, { options: finalOptions, path })
+              requestResponse: response,
+              error: this.errorUnwrap(error, { options: finalOptions, path })
             })
           })
         })

--- a/src/index.js
+++ b/src/index.js
@@ -84,28 +84,28 @@ export default {
   get (path: string, data: ?{}, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      merge({}, { method: 'GET' }, this.commonOptions, options, { data })
+      merge({ method: 'GET' }, this.commonOptions, options, { data })
     )
   },
 
   post (path: string, data: ?{}, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      merge({}, { method: 'POST' }, this.commonOptions, options, { data })
+      merge({ method: 'POST' }, this.commonOptions, options, { data })
     )
   },
 
   put (path: string, data: ?{}, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      merge({}, { method: 'PUT' }, this.commonOptions, options, { data })
+      merge({ method: 'PUT' }, this.commonOptions, options, { data })
     )
   },
 
   del (path: string, options?: {} = {}): OptionsRequest {
     return ajax(
       `${this.apiPath}${path}`,
-      merge({}, { method: 'DELETE' }, this.commonOptions, options)
+      merge({ method: 'DELETE' }, this.commonOptions, options)
     )
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ type Options = {
   headers?: ?{ [key: string]: string },
   onProgress?: (num: number) => mixed,
   data?: ?{ [key: string]: mixed },
-  qsOptions?: ?{ [key: mixed]: mixed }
+  qs?: ?{ [key: mixed]: mixed }
 }
 
 export function ajaxOptions (options: Options): any {
@@ -62,9 +62,9 @@ const adapter = {
     options = merge({}, this.defaults, { method }, options)
 
     if (method === 'GET' && options.data) {
-      url = `${url}?${qs.stringify(options.data, options.qsOptions)}`
+      url = `${url}?${qs.stringify(options.data, options.qs)}`
       delete options.data
-      delete options.qsOptions
+      delete options.qs
     }
 
     const xhr = fetch(url, ajaxOptions(options))

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 // @flow
 import qs from 'qs'
 import merge from 'lodash.merge'
-import ponyfill from 'fetch-ponyfill'
 
 type OptionsRequest = {
   abort: () => void,
@@ -19,19 +18,14 @@ type Options = {
 }
 
 export function ajaxOptions (options: Options): any {
-  let HeadersConstructor = Headers
   const { headers, data, ...otherOptions } = options
   const baseHeaders = {}
-
-  if (typeof HeadersConstructor === 'undefined') {
-    HeadersConstructor = ponyfill().Headers
-  }
 
   if (data) {
     baseHeaders['Content-Type'] = 'application/json'
   }
 
-  const headersObject = new HeadersConstructor(
+  const headersObject = new Headers(
     Object.assign(baseHeaders, headers)
   )
 
@@ -63,7 +57,6 @@ const adapter = {
 
   request (method: string, path: string, options?: {} = {}): OptionsRequest {
     let url = `${this.urlRoot}${path}`
-    let fetchMethod = fetch
     let rejectPromise
 
     options = merge({}, this.defaults, { method }, options)
@@ -74,11 +67,7 @@ const adapter = {
       delete options.qsOptions
     }
 
-    if (typeof fetchMethod === 'undefined') {
-      fetchMethod = ponyfill().fetch
-    }
-
-    const xhr = fetchMethod(url, ajaxOptions(options))
+    const xhr = fetch(url, ajaxOptions(options))
     const promise = new Promise((resolve, reject) => {
       rejectPromise = reject
       xhr.then(checkStatus).then(resolve, error => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,9 +1424,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.38.0:
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.38.0.tgz#3ae096d401c969cc8b5798253fb82381e2d0237a"
+flow-bin@^0.63.1:
+  version "0.63.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.63.1.tgz#ab00067c197169a5fb5b4996c8f6927b06694828"
 
 flow-copy-source@^1.1.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,7 +981,7 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-extend@^0.4.1, deep-extend@~0.4.0:
+deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
@@ -1059,12 +1059,6 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  dependencies:
-    iconv-lite "~0.4.13"
 
 errno@^0.1.4:
   version "0.1.4"
@@ -1364,12 +1358,6 @@ fb-watchman@^1.8.0, fb-watchman@^1.9.0:
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-1.9.2.tgz#a24cf47827f82d38fb59a69ad70b76e3b6ae7383"
   dependencies:
     bser "1.0.2"
-
-fetch-ponyfill@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-4.0.0.tgz#18cfe38d69cde42aec71cb3ace79e1f2276293da"
-  dependencies:
-    node-fetch "~1.6.0"
 
 figures@^1.3.5:
   version "1.7.0"
@@ -1700,7 +1688,7 @@ husky@^0.13.4:
     is-ci "^1.0.9"
     normalize-path "^1.0.0"
 
-iconv-lite@0.4.13, iconv-lite@~0.4.13:
+iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
@@ -1890,7 +1878,7 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2582,13 +2570,6 @@ node-emoji@^1.4.1:
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.5.1.tgz#fd918e412769bf8c448051238233840b2aff16a1"
   dependencies:
     string.prototype.codepointat "^0.2.0"
-
-node-fetch@~1.6.0:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
This works in conjunction with masylum/mobx-rest/pull/39.

# Changes
- Adds methods for `patch` and `head` requests.
- Adds method `errorUnwrap` that keeps the previous behavior of returning `error.errors || {}` when the request fails, but allows overriding.
- Allows to pass options to `qs.stringify`. In my particular case I'm doing this:

```es6
apiClient(adapter, {
  defaults: { // Previously `commonOptions`
    qs: {
      arrayFormat: 'brackets'
    }
  }
})
```

# Breaking changes
- Renames `apiPath` to `urlRoot`.
- Renames `commonOptions` to `defaults`.
- Removes `fetch-ponyfill`. If the host app already has a polyfill this will just be adding unused bytes. I think the developer should include a fetch polyfill in his app, if needed.
- Rejections now returns `{ requestResponse, error }`, `requestResponse` being the original request response object and `error` the result of `errorUnwrap`. This allows to get response headers, status, etc.

# Fixes
- Sets `undefined` body when `options.data` is not specified. https://github.com/github/fetch/issues/402

# Notes
We aren't using the `jquery-adapter`, so these changes will have to be applied/tested there also.