### PR TITLE
Add error callback when fetch handles an error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ type Options = {
   method: Method,
   headers?: ?{ [key: string]: string },
   onProgress?: (num: number) => mixed,
-  data?: ?{ [key: string]: mixed }
+  data?: ?{ [key: string]: mixed },
+  errorCallBack: (mixed) => void
 }
 
 export function ajaxOptions (options: Options): any {
@@ -65,6 +66,11 @@ function ajax (url: string, options: Options): OptionsRequest {
     rejectPromise = reject
     xhr.then(checkStatus).then(resolve, error => {
       const ret = error ? error.errors : {}
+      
+      if(options.errorCallBack !== undefined) {
+			// Call error function here
+			options.errorCallBack(ret);
+      }
 
       return reject(ret || {})
     })


### PR DESCRIPTION
Hello, 

I wanted to do this PR that I found useful for my project : 
When creating APIClient, provide an errorCallback method that will be called in case of rest fetch error 

**How to use it :**
```js

const handleErrors = (error) => {
    if(error.status === 401)) {
        loginServices.invalidateUser();
        window.location = '/'; 
    }
}
const options = {
     apiPath: apiPath,
     commonOptions: {
         errorCallBack : handleErrors
     }
}
       
return apiClient(adapter, options);
```